### PR TITLE
fix: get build of beaker-server/beaker-lab-controller containers working

### DIFF
--- a/beaker-lab-controller/Dockerfile
+++ b/beaker-lab-controller/Dockerfile
@@ -4,6 +4,8 @@ RUN yum upgrade -y && \
   yum -y install epel-release dnf dnf-plugins-core
 RUN yum-config-manager --save --setopt=epel.exclude=nodejs*,npm
 COPY files/beaker-server-RedHatEnterpriseLinux.repo /etc/yum.repos.d/beaker-server-RedHatEnterpriseLinux.repo
+# `mirrorlist.centos.org` no longer exists. Use `vault.centos.org`
+COPY files/centos-7-vault.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN dnf -y copr enable bpeck/beaker && \
   dnf -y copr enable bpeck/ipmitool && \
   yum -y install beaker-lab-controller && \

--- a/beaker-lab-controller/files/beaker-server-RedHatEnterpriseLinux.repo
+++ b/beaker-lab-controller/files/beaker-server-RedHatEnterpriseLinux.repo
@@ -2,8 +2,8 @@
 name=Beaker Server - RedHatEnterpriseLinux$releasever
 baseurl=https://beaker-project.org/yum/server/RedHatEnterpriseLinux$releasever/
 enabled=1
-gpgcheck=0
-gpgkey=https://beaker-project.org/gpg/RPM-GPG-KEY-redhatengsystems https://fedoraproject.org/static/352C64E5.txt
+gpgcheck=1
+gpgkey=https://beaker-project.org/gpg/RPM-GPG-KEY-redhatengsystems https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever https://download.copr.fedorainfracloud.org/results/@beaker-project/beaker/pubkey.gpg https://download.copr.fedorainfracloud.org/results/@beaker-project/nodejs-less/pubkey.gpg
 
 [beaker-server-testing]
 name=Beaker Server - RedHatEnterpriseLinux$releasever - Testing

--- a/beaker-lab-controller/files/centos-7-vault.repo
+++ b/beaker-lab-controller/files/centos-7-vault.repo
@@ -1,0 +1,49 @@
+# NOTE: This has been modified to use `vault.centos.org` as `mirrorlist.centos.org` is gone
+#
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/beaker-server/Dockerfile
+++ b/beaker-server/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 LABEL name="beaker-server-container"
 COPY files/beaker-server-RedHatEnterpriseLinux.repo /etc/yum.repos.d
+# `mirrorlist.centos.org` no longer exists. Use `vault.centos.org`
+COPY files/centos-7-vault.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN yum upgrade -y && \
   yum -y install epel-release dnf dnf-plugins-core
 RUN yum-config-manager --save --setopt=epel.exclude=nodejs*,npm

--- a/beaker-server/files/beaker-server-RedHatEnterpriseLinux.repo
+++ b/beaker-server/files/beaker-server-RedHatEnterpriseLinux.repo
@@ -3,7 +3,7 @@ name=Beaker Server - RedHatEnterpriseLinux$releasever
 baseurl=https://beaker-project.org/yum/server/RedHatEnterpriseLinux$releasever/
 enabled=1
 gpgcheck=1
-gpgkey=https://beaker-project.org/gpg/RPM-GPG-KEY-redhatengsystems https://raw.githubusercontent.com/josemalcher/fedora-web/master/fedoraproject.org/static/352C64E5.txt
+gpgkey=https://beaker-project.org/gpg/RPM-GPG-KEY-redhatengsystems https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever https://download.copr.fedorainfracloud.org/results/@beaker-project/beaker/pubkey.gpg https://download.copr.fedorainfracloud.org/results/@beaker-project/nodejs-less/pubkey.gpg
 
 [beaker-server-testing]
 name=Beaker Server - RedHatEnterpriseLinux$releasever - Testing

--- a/beaker-server/files/centos-7-vault.repo
+++ b/beaker-server/files/centos-7-vault.repo
@@ -1,0 +1,49 @@
+# NOTE: This has been modified to use `vault.centos.org` as `mirrorlist.centos.org` is gone
+#
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7


### PR DESCRIPTION
There is no longer a `mirrorlist.centos.org`. So change CentOS repo file to use `vault.centos.org`

Also update repo file for the beaker-project to have the correct GPG keys.